### PR TITLE
Show only General Election candidates in UI

### DIFF
--- a/app/routes/bills.js
+++ b/app/routes/bills.js
@@ -9,7 +9,6 @@ router.get('/', function(req, res, next) {
   var selectClause = 'SELECT billId, officialTitle,url, sponsorId FROM bills';
   var params;
   db.each(selectClause, params, function(err, row) {
-    console.log(row);
     bills.push(row);
   }, function() {
     res.send(bills);
@@ -21,7 +20,6 @@ router.get('/sponsor', function(req, res, next) {
   var selectClause = 'SELECT cosponsorId, billId FROM cosponsors_bills';
   var params;
   db.each(selectClause, params, function(err, row) {
-    console.log(row);
     sponsors.push(row);
   }, function() {
     res.send(sponsors);


### PR DESCRIPTION
Added in logic to show only those running in the general election if the primary has already been held. Relies on the "gen_election_candidate" field in the DB being set to "1" for any candidate who has won the primary and/or is running in the general election.
